### PR TITLE
Added missing cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+
+add_library(capsense INTERFACE)
+
+
+target_sources(capsense
+    INTERFACE
+        cy_capsense_control.c
+        cy_capsense_tuner.c
+        cy_capsense_centroid.c
+        cy_capsense_csx_v2.c
+        cy_capsense_csd_v2.c
+        cy_capsense_filter.c
+        cy_capsense_generator_v3.c
+        cy_capsense_processing.c
+        cy_capsense_selftest.c
+        cy_capsense_sensing_v2.c
+        cy_capsense_sensing_v3.c
+        cy_capsense_structure.c
+       
+)


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/cypresssemiconductorco/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
 Current Capsense library doesn't contain  any build scripts  so  adding it as a git submodule requires creating and copy cmake or gn  file   or adding all source files to project repository. 
This is unconvinient and prevents to use git submodules  benefits. 
It would be nice to have at least cmake.

Related Issue
 

Context
What do we need to know about your development environment, tools, target, and so on. Screenshots are always helpful if there is a UI element to this PR.